### PR TITLE
Auto-discover sometimes returns duplicate responses

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 	"extensions": [
 		"dbaeumer.vscode-eslint",
 		"ms-vscode.vscode-typescript-tslint-plugin",
-		"esbenp.prettier-vscode"
+		"esbenp.prettier-vscode",
+		"davidanson.vscode-markdownlint"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Miscellaneous auto-discovery improvements. Resolves [issue 29](https://github.com/danecreekphotography/node-red-contrib-wled2/issues/23) and [issue 30](https://github.com/danecreekphotography/node-red-contrib-wled2/issues/23).
+
 ## v1.2.1 - 2020-07-03
 
 - Auto-discovery now works for NodeRed installs hosted inside Home Assistant. Resolves [issue 27](https://github.com/danecreekphotography/node-red-contrib-wled2/issues/23).

--- a/src/controllers/discover.ts
+++ b/src/controllers/discover.ts
@@ -84,6 +84,9 @@ export default async function discover(request: express.Request, response: expre
   // After the discovery is complete respond with the results
   setTimeout(() => {
     browser.destroy();
-    response.json(wledDevices);
+    // This nonsense de-duplicates the array. Since TypeScript can't use
+    // the spread operator on a Set it has to get converted to an array
+    // first.
+    response.json([...Array.from(new Set(wledDevices))]);
   }, timeout);
 }


### PR DESCRIPTION
Fixes #29

## Description of changes

- Deduplicate the list of discovered devices before returning it

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
