### PR TITLE
Support toggling the entire LED set on and off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- Toggling the lights on/off based on current LED state is now supported. This is done with the new `state` property which replaces the `on` property.
+  Valid values are `on`, `off`, and `toggle`. The `delay` feature is supported for toggling as well and will correctly play the effect for the specified
+  duration before toggling the light state. Resolves [issue 52](https://github.com/danecreekphotography/node-red-contrib-wled2/issues/52).
+
 ## v1.4.0 - 2020-07-05
 
 - All logged warnings now report through NodeRed logging systems instead of console logs. Resolves [issue 40](https://github.com/danecreekphotography/node-red-contrib-wled2/issues/40).

--- a/src/WledDevice.ts
+++ b/src/WledDevice.ts
@@ -46,6 +46,19 @@ export default class WledDevice extends EventEmitter {
   }
 
   /**
+   * Gets the current on state for a WLED device. Basically the same
+   * as getting the state, but only returning a single property.
+   * @returns True if the light is on, false otherwise.
+   */
+  public async getCurrentOnState(): Promise<boolean> {
+    await this.getState().catch(e => {
+      this.setConnectionState(false);
+      throw e;
+    });
+    return this.currentState.on;
+  }
+
+  /**
    * Sets a WLED device's state
    * @param state The state to send to the WLED device
    */

--- a/src/types/IWledNodeProperties.ts
+++ b/src/types/IWledNodeProperties.ts
@@ -14,7 +14,7 @@ export default interface IWledNodeProperties extends NodeProperties {
   effectIntensity: number;
   effectSpeed: number;
   name: string;
-  on: string;
+  state: string;
   delay: number;
   palette: number;
 }

--- a/src/wled2.html
+++ b/src/wled2.html
@@ -14,7 +14,7 @@
       effectSpeed: { value: 128 },
       name: { value: "" },
       palette: { value: "0" },
-      on: { value: "true", required: true },
+      on: { value: "on" },
     },
     inputs: 1,
     outputs: 1,
@@ -31,11 +31,6 @@
       $("#node-input-delay").typedInput({
         type: "num",
         types: ["num"],
-      });
-
-      $("#node-input-on").typedInput({
-        type: "bool",
-        types: ["bool"],
       });
 
       $("#node-config-discover").click(function() {
@@ -190,8 +185,12 @@
       </div>
     </div>
     <div class="form-row">
-      <label for="node-input-on"><i class="icon-tag"></i> On</label>
-      <input type="text" id="node-input-on" placeholder="true">
+      <label for="node-input-state"><i class="icon-tag"></i> State</label>
+      <select id="node-input-state">
+        <option value="on">on</option>
+        <option value="off">off</option>
+        <option value="toggle">toggle</option>
+      </select>
     </div>
     <div class="form-row">
       <label for="node-input-brightness"><i class="icon-tag"></i> Level</label>


### PR DESCRIPTION
Fixes #52

## Description of changes

- Changes the mechanism for turning the lights on/off from the `on` property to a `state` property which supports on, off, and toggle.
- A bunch of additional error handling code added

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
