### PR TITLE
Alter state request to affect all segments

### DIFF
--- a/src/types/IWLedState.ts
+++ b/src/types/IWLedState.ts
@@ -7,5 +7,5 @@ import IWledSegment from "./IWledSegment";
 export default interface IWledState {
   on?: boolean;
   effect?: number;
-  seg?: IWledSegment[];
+  seg?: IWledSegment | IWledSegment[];
 }

--- a/src/types/IWledSegment.ts
+++ b/src/types/IWledSegment.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 export default interface IWledSegment {
-  id: number;
+  id?: number;
   start?: number;
   stop?: number;
   len?: number;

--- a/src/wled2.ts
+++ b/src/wled2.ts
@@ -97,20 +97,17 @@ export = (RED: Red): void => {
     const state = {
       on,
       bri: payload.brightness ?? Number(this.config.brightness),
-      seg: [
-        {
-          col: [
-            payload.color1 ?? helpers.hexToRgb(this.config.color1),
-            payload.color2 ?? helpers.hexToRgb(this.config.color2),
-            payload.color3 ?? helpers.hexToRgb(this.config.color3),
-          ],
-          fx: payload.effect ?? Number(this.config.effect),
-          id: 0,
-          ix: payload.effectIntensity ?? Number(this.config.effectIntensity),
-          pal: payload.palette ?? Number(this.config.palette),
-          sx: payload.effectSpeed ?? Number(this.config.effectSpeed),
-        } as IWledSegment,
-      ],
+      seg: {
+        col: [
+          payload.color1 ?? helpers.hexToRgb(this.config.color1),
+          payload.color2 ?? helpers.hexToRgb(this.config.color2),
+          payload.color3 ?? helpers.hexToRgb(this.config.color3),
+        ],
+        fx: payload.effect ?? Number(this.config.effect),
+        ix: payload.effectIntensity ?? Number(this.config.effectIntensity),
+        pal: payload.palette ?? Number(this.config.palette),
+        sx: payload.effectSpeed ?? Number(this.config.effectSpeed),
+      } as IWledSegment,
     } as IWledState;
 
     // On failures the node can just do nothing. Error state


### PR DESCRIPTION
Fixes #72 

This pull request will use an undocumented aspect of the JSON API, that can be seen when observing the network requests from the built-in UI, to update all segments, rather than the first segment.

It turns out, when `seg` receives an object without an ID instead of an array it applies to all segments for the light.

Tested locally.

Related to #61 but not a perfect solution
